### PR TITLE
Update camerasettings_settings.jinja2

### DIFF
--- a/octoprint_CameraSettings/templates/camerasettings_settings.jinja2
+++ b/octoprint_CameraSettings/templates/camerasettings_settings.jinja2
@@ -121,7 +121,7 @@
     {{ menu_control('h264_level', 'H.264 Level') }}
     {{ menu_control('h264_profile', 'H.264 Profile') }}
 
-    {{ bool_control('privacy', 'Privacy') }}
+    {{ bool_control('privacy', 'Privacy Sheild is down:') }}
 </div>
 <hr>
 

--- a/octoprint_CameraSettings/templates/camerasettings_settings.jinja2
+++ b/octoprint_CameraSettings/templates/camerasettings_settings.jinja2
@@ -121,7 +121,7 @@
     {{ menu_control('h264_level', 'H.264 Level') }}
     {{ menu_control('h264_profile', 'H.264 Profile') }}
 
-    {{ bool_control('privacy', 'Privacy Sheild is down:') }}
+    {{ bool_control('privacy', 'Privacy Shield is down') }}
 </div>
 <hr>
 


### PR DESCRIPTION
Make "privacy" value more descriptive.

We have the option to create a warning for if the shield is down, however I feel this setting will be hardly supported on cameras, but leaving it as is, is the easiest solution to keep it around while displaying its value, as I stated in my issue, the checkbox does **nothing** so it could be a basic indicator if the webcam supports it.