### PR TITLE
Support multiple camera previews with OctoPrint-MultiCam

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,3 +29,7 @@ See [v4l-utils in setup](setup.md#v4l-utils).
 Some settings can only be set after other settings meet certain conditions. For example, on some cameras exposure time can only be set if exposure auto is off. Unfortunately, the plugin has no way of knowing these dependecies, but it is possible to load a preset multiple times on startup to work around this.
 
 This can be done by changing the 'Startup Preset Apply Count' number in the plugin settings to 2 or more.
+
+## I have multiple cameras but the preview doesn't change when I select a different camera in the dropdown
+
+The preview shown is the same stream that is configured in OctoPrint. If you have multiple cameras, you may also want to use the [MultiCam](https://plugins.octoprint.org/plugins/multicam/) plugin. If that plugin is installed, Camera Settings will detect it and allow you to link the cameras detected to profiles defined in MultiCam. If `OctoPrint-MultiCam Integration` is enabled, the preview shown will use the settings in the appropriate profile, allowing you to view the preview for multiple cameras.

--- a/octoprint_CameraSettings/__init__.py
+++ b/octoprint_CameraSettings/__init__.py
@@ -60,7 +60,9 @@ class CameraSettingsPlugin(octoprint.plugin.SettingsPlugin,
             presets=[],
             load_preset_on_startup=False,
             startup_preset_name=None,
-            startup_preset_apply_count=1
+            startup_preset_apply_count=1,
+            multicam_support=False,
+            multicam_mapping=[]
         )
 
     def exclude_camera(self, name):
@@ -153,6 +155,16 @@ class CameraSettingsPlugin(octoprint.plugin.SettingsPlugin,
 
             for dev in video_ctrls:
                 if len(video_ctrls[dev])==0: del video_devices[dev]
+
+            cam_names = [video_devices[d] for d in video_devices]
+            cam_map = self._settings.get(['multicam_mapping'])
+            for cam in cam_names:
+                if len([x for x in cam_map if x['camera']==cam])==0: cam_map.append({'camera': cam, 'multicam': None})
+            
+            for c in range(len(cam_map)):
+                if (cam_map[c]['camera'] not in cam_names): del cam_map[c]
+            
+            self._settings.set(['multicam_mapping'], cam_map)
 
             self._logger.debug("Cameras found: {0}".format([{'device': d, 'camera': video_devices[d]} for d in video_devices]))
             self._event_bus.fire(event, payload={'cameras': [{'device': d, 'camera': video_devices[d]} for d in video_devices]})

--- a/octoprint_CameraSettings/templates/camerasettings_settings.jinja2
+++ b/octoprint_CameraSettings/templates/camerasettings_settings.jinja2
@@ -46,7 +46,7 @@
     <div class="span8">
         <div class="camPreviewContainerOuter" data-bind="visible: settings.settings.plugins.camerasettings.show_preview">
             <div class="camPreviewContainer">
-                <img data-bind="attr: { src: cameraSrc }, style: { transform: `scaleX(${settings.settings.webcam.flipH() ? -1: 1}) scaleY(${settings.settings.webcam.flipV() ? -1: 1})`}" class="camPreview">
+                <img data-bind="attr: { src: cameraSrc }, style: { transform: `rotate(${cameraRot90() ? '-90deg': '0deg'}) scaleX(${cameraFlipH() ? -1: 1}) scaleY(${cameraFlipV() ? -1: 1})`}" class="camPreview">
             </div>
         </div>
     </div>
@@ -185,4 +185,28 @@
     <div class="span4">
         <input type="number" data-bind="value: settings.settings.plugins.camerasettings.startup_preset_apply_count">
     </div>
+</div>
+<hr>
+<div class="row-fluid">
+    <div class="span4 text-right">OctoPrint-MultiCam Integration</div>
+    <div class="span4">
+        <input type="checkbox" class="checkbox" data-bind="checked: settings.settings.plugins.camerasettings.multicam_support, enable: settings.settings.plugins.multicam !== undefined">
+    </div>
+</div>
+
+
+<div data-bind="foreach: {data: settings.settings.plugins.camerasettings.multicam_mapping, as: 'mapping', noChildContext: true}, visible: settings.settings.plugins.multicam !== undefined">
+
+<div class="row-fluid">
+    <div class="span4 text-right" data-bind="text: mapping.camera"></div>
+    <div class="span4">
+        <select data-bind=",
+            options: settings.settings.plugins.multicam.multicam_profiles,
+            optionsText: (profile) => profile.name,
+            optionsValue: (profile) => profile.name,
+            value: mapping.multicam,
+            valueAllowUnset: true "></select>
+    </div>
+</div>
+
 </div>


### PR DESCRIPTION
Initial multiple camera preview support.

This will only work if you also have the most recent version of the 'MultiCam' plugin installed.

With these changes, the plugin will detect that MultiCam is installed and allow mapping detected cameras to profiles in MultiCam:
![image](https://user-images.githubusercontent.com/7342077/118275179-17a85780-b494-11eb-8a60-737b6ff450bd.png)

![image](https://user-images.githubusercontent.com/7342077/118279805-8c31c500-b499-11eb-8c77-90bb2cd7a17a.png)

And, if 'OctoPrint-MultiCam Integration' is enabled, the preview will use the URL and flip, rotate settings from the MultiCam profile:

https://user-images.githubusercontent.com/7342077/118275487-77066780-b494-11eb-981f-000ff0dd9ac4.mp4

If anyone would like to test this out now, you can by installing the plugin from the branch URL: https://github.com/The-EG/OctoPrint-CameraSettings/archive/refs/heads/feature/multicam.zip
No uninstall necessary, just install it over the existing version.

Fixes #28 
